### PR TITLE
Fix capitalization "hostingInstitution" to "HostingInstitution"

### DIFF
--- a/docs/guidance/software-citation.rst
+++ b/docs/guidance/software-citation.rst
@@ -19,9 +19,9 @@ Documentation updates
    * - :ref:`3`
      - Add: "May be the title of a dataset or the name of a piece of software."
    * - :ref:`4`
-     - Add: "For software, use Publisher for Code Repository, following the data model. If there is an alternate entity that "holds, archives, publishes, prints, distributes, releases, issues, or produces" the code, use the contributorType "hostingInstitution" for the code repository."
+     - Add: "For software, use Publisher for Code Repository, following the data model. If there is an alternate entity that "holds, archives, publishes, prints, distributes, releases, issues, or produces" the code, use the contributorType "HostingInstitution" for the code repository."
    * - :ref:`7`
-     - Add: "For software, if there is an alternate entity that "holds, archives, publishes, prints, distributes, releases, issues, or produces" the code, use the contributorType "hostingInstitution" for the code repository."
+     - Add: "For software, if there is an alternate entity that "holds, archives, publishes, prints, distributes, releases, issues, or produces" the code, use the contributorType "HostingInstitution" for the code repository."
    * - :ref:`5`
      - Add: "In the case of resources such as software where there may be multiple releases in one year, other DataCite metadata or information such as the landing page should enable users to identify the newest one."
    * - :ref:`10.a`

--- a/docs/mappings/pidinst.rst
+++ b/docs/mappings/pidinst.rst
@@ -27,7 +27,7 @@ Table 7: PIDINST to DataCite Mapping
    * - **Owner**
      - | :ref:`7` with :ref:`7.a`:
        | :ref:`HostingInstitution`
-     - Can be used for the owner of an instrument, i.e. the institution responsible for the management of the instrument. This may include the legal owner, the operator, or an institute providing access to the instrument. Use the contributorType “hostingInstitution”. The instrument owner may also be included in :ref:`4`. [#f2]_
+     - Can be used for the owner of an instrument, i.e. the institution responsible for the management of the instrument. This may include the legal owner, the operator, or an institute providing access to the instrument. Use the contributorType "HostingInstitution". The instrument owner may also be included in :ref:`4`. [#f2]_
    * - ownerName
      - :ref:`7.1`
      -

--- a/docs/properties/contributor.rst
+++ b/docs/properties/contributor.rst
@@ -9,9 +9,9 @@
 
 **Definition:** The institution or person responsible for collecting, managing, distributing, or otherwise contributing to the development of the resource. To supply multiple contributors, repeat this property.
 
-For software, if there is an alternate entity that "holds, archives, publishes, prints, distributes, releases, issues, or produces" the code, use the contributorType "hostingInstitution" for the code repository.
+For software, if there is an alternate entity that "holds, archives, publishes, prints, distributes, releases, issues, or produces" the code, use the contributorType "HostingInstitution" for the code repository.
 
-For instruments, if there is an institution responsible for the management of the instrument (for example, the legal owner, the operator, or an institute providing access to the instrument), use the contributorType “hostingInstitution” for the owner of the instrument.
+For instruments, if there is an institution responsible for the management of the instrument (for example, the legal owner, the operator, or an institute providing access to the instrument), use the contributorType "HostingInstitution" for the owner of the instrument.
 
 **Allowed values, examples, other constraints:**
 

--- a/docs/properties/publisher.rst
+++ b/docs/properties/publisher.rst
@@ -9,7 +9,7 @@
 
 **Definition:** The name of the entity that holds, archives, publishes, prints, distributes, releases, issues, or produces the resource. This property will be used to formulate the citation, so consider the prominence of the role.
 
-For software, use Publisher for the code repository. If there is an entity other than a code repository, that "holds, archives, publishes, prints, distributes, releases, issues, or produces" the code, use the property :ref:`7` with contributorType "hostingInstitution" for the code repository.
+For software, use Publisher for the code repository. If there is an entity other than a code repository, that "holds, archives, publishes, prints, distributes, releases, issues, or produces" the code, use the property :ref:`7` with contributorType "HostingInstitution" for the code repository.
 
 **Allowed values, examples, other constraints:**
 


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

There were a few places where `HostingInstitution` was capitalized as `hostingInstitution`. This PR changes these to be consistent with the usual capitalization for contributorType values.

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
